### PR TITLE
FIX for incorrect exit on non pi user

### DIFF
--- a/install
+++ b/install
@@ -1,5 +1,8 @@
 # check if the install script is run by the 'pi' user
-[ `whoami` != pi ] && echo "Please run this script as 'pi' user"; exit 1
+if [ `whoami` != pi ]; then
+        echo "Please run as 'pi' user"
+        exit 1
+fi
 
 # kill any running gtk_battery command so that it can be overwritten
 pkill gtk_battery


### PR DESCRIPTION
sorry @rricharz I thought that was working, I've rewritten the check. Previously the exit was run anyway preventing the actual install.