### PR TITLE
Write red, warning and shutdown levels to log destination

### DIFF
--- a/gtk_battery.c
+++ b/gtk_battery.c
@@ -428,25 +428,28 @@ int main(int argc, char *argv[])
 	FILE *confFile;
 	confFile = fopen("/home/pi/.config/pi-top/gtk_battery.txt","r");
   	if (confFile == NULL) {
-		fprintf(logFile,"Cannot open /home/pi/.config/pi-top/gtk_battery.txt\n");
-		return 1;
+		fprintf(logFile,"Cannot open /home/pi/.config/pi-top/gtk_battery.txt, using defaults\n");
+		redLevel = 10;
+		warningLevel = 8;
+		shutdownLevel = 5;
 	}
-
-	fscanf(confFile, "red=%d\n", &redLevel);
-	if (redLevel < 10) redLevel = 10;
-	if (redLevel > 90) redLevel = 90;
-	fscanf(confFile, "warning=%d\n", &warningLevel);
-	if (warningLevel < 8) warningLevel = 8;
-	if (warningLevel > 90) warningLevel = 90;
- 	fscanf(confFile, "shutdown=%d\n", &shutdownLevel);
-	if (shutdownLevel < 5) shutdownLevel = 5;
-	if (shutdownLevel > 88) shutdownLevel = 88;
-	if (warningLevel < shutdownLevel + 2) warningLevel = shutdownLevel + 2;
-	if (redLevel < warningLevel) redLevel = warningLevel;
+	else {
+		fscanf(confFile, "red=%d\n", &redLevel);
+		if (redLevel < 10) redLevel = 10;
+		if (redLevel > 90) redLevel = 90;
+		fscanf(confFile, "warning=%d\n", &warningLevel);
+		if (warningLevel < 8) warningLevel = 8;
+		if (warningLevel > 90) warningLevel = 90;
+		fscanf(confFile, "shutdown=%d\n", &shutdownLevel);
+		if (shutdownLevel < 5) shutdownLevel = 5;
+		if (shutdownLevel > 88) shutdownLevel = 88;
+		if (warningLevel < shutdownLevel + 2) warningLevel = shutdownLevel + 2;
+		if (redLevel < warningLevel) redLevel = warningLevel;
+		
+		fclose(confFile);
+	}
 	
 	lowBattery = warningLevel;
-
-	fclose(confFile);
   
 	fprintf(logFile,"red=%d\n", redLevel);
 	fprintf(logFile,"warning=%d\n", warningLevel);

--- a/gtk_battery.c
+++ b/gtk_battery.c
@@ -448,9 +448,9 @@ int main(int argc, char *argv[])
 
 	fclose(confFile);
   
-	printf("red=%d\n", redLevel);
-	printf("warning=%d\n", warningLevel);
-	printf("shutdown=%d\n", shutdownLevel);
+	fprintf(logFile,"red=%d\n", redLevel);
+	fprintf(logFile,"warning=%d\n", warningLevel);
+	fprintf(logFile,"shutdown=%d\n", shutdownLevel);
 
 	gtk_init(&argc, &argv);
 	


### PR DESCRIPTION
I wondered, probably you'd like to write everything to the log destination (all other occurrences of printf are commented out).